### PR TITLE
Hotfix Broken Migration (take 2)

### DIFF
--- a/api/src/db/migrations/2024.06.10T18.01.34.backfill-user-groups-acronyms.ts
+++ b/api/src/db/migrations/2024.06.10T18.01.34.backfill-user-groups-acronyms.ts
@@ -10,10 +10,9 @@ export const up: Migration = async ({ context: queryInterface }) => {
   do {
     userGroups = await queryInterface.sequelize.query(
       /* sql */ `
-        SELECT id, name FROM user_groups
+        SELECT TOP (:limit) id, name FROM user_groups
         WHERE id > :lastId
         ORDER BY id ASC
-        LIMIT :limit
       `,
       {
         replacements: {


### PR DESCRIPTION
:bug: Fix backfill-user-groups-acronyms migration use MSSQL syntax instead of PostgreSQL.